### PR TITLE
Fix server static assets build

### DIFF
--- a/packages/backend/server/package.json
+++ b/packages/backend/server/package.json
@@ -8,6 +8,8 @@
     "run-test": "./scripts/run-test.ts"
   },
   "scripts": {
+    "build:static": "r ./scripts/build-static.ts",
+    "prebuild": "yarn build:static",
     "build": "affine bundle -p @affine/server",
     "dev": "nodemon ./src/index.ts",
     "dev:mail": "email dev -d src/mails",

--- a/packages/backend/server/scripts/build-static.ts
+++ b/packages/backend/server/scripts/build-static.ts
@@ -1,0 +1,74 @@
+import { execSync } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+interface StaticPackage {
+  name: string;
+  dist: string;
+  target: string;
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+const serverRoot = path.resolve(__dirname, '..');
+
+const staticPackages: StaticPackage[] = [
+  {
+    name: '@affine/web',
+    dist: path.join(repoRoot, 'packages/frontend/apps/web/dist'),
+    target: path.join(serverRoot, 'static'),
+  },
+  {
+    name: '@affine/mobile',
+    dist: path.join(repoRoot, 'packages/frontend/apps/mobile/dist'),
+    target: path.join(serverRoot, 'static/mobile'),
+  },
+  {
+    name: '@affine/admin',
+    dist: path.join(repoRoot, 'packages/frontend/admin/dist'),
+    target: path.join(serverRoot, 'static/admin'),
+  },
+];
+
+function run(command: string) {
+  execSync(command, {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    env: process.env,
+  });
+}
+
+function prepareTarget(target: string) {
+  rmSync(target, { recursive: true, force: true });
+  mkdirSync(path.dirname(target), { recursive: true });
+}
+
+function copyDist(dist: string, target: string) {
+  if (!existsSync(dist)) {
+    throw new Error(`Expected build output at ${dist}, but it does not exist.`);
+  }
+
+  prepareTarget(target);
+  cpSync(dist, target, { recursive: true, force: true });
+}
+
+function buildStaticAssets() {
+  for (const pkg of staticPackages) {
+    console.log(`Building static assets for ${pkg.name}...`);
+    run(`yarn affine bundle --package ${pkg.name}`);
+    console.log(`Copying ${pkg.dist} -> ${pkg.target}`);
+    copyDist(pkg.dist, pkg.target);
+  }
+}
+
+try {
+  if (process.env.SKIP_STATIC_ASSETS === 'true') {
+    console.log('Skipping static asset build because SKIP_STATIC_ASSETS=true');
+  } else {
+    buildStaticAssets();
+  }
+} catch (err) {
+  console.error('Failed to build static assets.');
+  throw err;
+}


### PR DESCRIPTION
## Summary
- add a build-static helper that bundles the web, mobile, and admin frontends and copies their outputs into the server static directory
- hook the static build into the @affine/server build lifecycle so production images include assets-manifest.json

## Testing
- ⚠️ `yarn workspace @affine/server build:static` *(terminated early because the webpack bundle takes too long for the current sandbox runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68e421c9c00c8324a41034d3ea212a6b