### PR TITLE
Fix doc renderer fallback when manifest missing

### DIFF
--- a/packages/backend/server/src/__tests__/doc/renderer.spec.ts
+++ b/packages/backend/server/src/__tests__/doc/renderer.spec.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import { Package } from '@affine-tools/utils/workspace';
@@ -8,6 +9,8 @@ import ava from 'ava';
 import request from 'supertest';
 
 import { createTestingApp } from '../utils';
+import { DocRendererController } from '../../core/doc-renderer/controller';
+import { NodeEnv } from '../../env';
 
 const test = ava as TestFn<{
   app: INestApplication;
@@ -84,3 +87,32 @@ test.skip('should render correct mobile html', async t => {
 });
 
 test.todo('should render correct page preview');
+
+test.serial(
+  'should fall back to default assets when manifest is missing',
+  t => {
+    const tmpStatic = mkdtempSync(path.join(tmpdir(), 'doc-renderer-'));
+    const originalNodeEnv = env.NODE_ENV;
+    env.NODE_ENV = NodeEnv.Production;
+
+    try {
+      const controller = new DocRendererController(
+        {} as any,
+        {} as any,
+        { server: { path: '/' } } as any
+      );
+
+      const assets = (controller as any).readHtmlAssets(tmpStatic);
+
+      t.deepEqual(assets, {
+        css: [],
+        js: [],
+        publicPath: '/',
+        gitHash: '',
+        description: '',
+      });
+    } finally {
+      env.NODE_ENV = originalNodeEnv;
+    }
+  }
+);

--- a/packages/backend/server/src/core/doc-renderer/controller.ts
+++ b/packages/backend/server/src/core/doc-renderer/controller.ts
@@ -223,12 +223,22 @@ export class DocRendererController {
       assets.css = assets.css.map(path => publicPath + path);
 
       return assets;
-    } catch (e) {
-      if (env.prod) {
-        throw e;
-      } else {
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+
+      if (err.code === 'ENOENT') {
+        this.logger.warn(
+          `HTML assets manifest not found at ${manifestPath}, falling back to defaults.`
+        );
         return defaultAssets;
       }
+
+      if (env.prod) {
+        throw err;
+      }
+
+      this.logger.error('Failed to load HTML assets manifest', err);
+      return defaultAssets;
     }
   }
 }


### PR DESCRIPTION
## Summary
- avoid crashing when the doc renderer cannot find assets-manifest.json by logging a warning and returning default assets
- cover the fallback path with a regression test that exercises the production code path

## Testing
- yarn workspace @affine/server test -- --match="doc/renderer" *(fails: Node cannot load TypeScript prelude without the expected loader in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e441ebfd7c83249d0196ac194cb601