### PR TITLE
Update migration image for self-host compose

### DIFF
--- a/docker-compose.self-host.yml
+++ b/docker-compose.self-host.yml
@@ -33,7 +33,7 @@ services:
     restart: unless-stopped
 
   affine_migration:
-    image: ghcr.io/toeverything/affine:stable
+    image: ghcr.io/cognifex/affine:latest
     container_name: affine_migration_job
     command: ["sh", "-c", "node ./scripts/self-host-predeploy.js"]
     depends_on:


### PR DESCRIPTION
## Summary
- point the affine_migration service to ghcr.io/cognifex/affine:latest
- ensure migrations continue to run via the self-host predeploy script

## Testing
- docker compose up -d --force-recreate *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e918c9c1308324b0794066079c247c