### PR TITLE
Update migration image for self-host compose

### DIFF
--- a/.docker/selfhost/compose.yml
+++ b/.docker/selfhost/compose.yml
@@ -24,7 +24,7 @@ services:
     restart: unless-stopped
 
   affine_migration:
-    image: ghcr.io/toeverything/affine:stable
+    image: ghcr.io/cognifex/affine:latest
     container_name: affine_migration_job
     volumes:
       - /c/Users/timhe/.affine/self-host/storage:/root/.affine/storage
@@ -66,7 +66,7 @@ services:
       POSTGRES_INITDB_ARGS: "--data-checksums"
       POSTGRES_HOST_AUTH_METHOD: trust
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "${DB_USERNAME}", "-d", "${DB_DATABASE:-affine}"]
+      test: ["CMD", "pg_isready", "-U", "${DB_USERNAME:-postgres}", "-d", "${DB_DATABASE:-affine}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.self-host.yml
+++ b/docker-compose.self-host.yml
@@ -4,7 +4,7 @@ services:
     image: ghcr.io/cognifex/affine:latest
     container_name: affine_server
     ports:
-      - "3010:3010"
+      - '3010:3010'
     healthcheck:
       test:
         - CMD-SHELL
@@ -35,7 +35,7 @@ services:
   affine_migration:
     image: ghcr.io/cognifex/affine:latest
     container_name: affine_migration_job
-    command: ["sh", "-c", "node ./scripts/self-host-predeploy.js"]
+    command: ['sh', '-c', 'node ./scripts/self-host-predeploy.js']
     depends_on:
       postgres:
         condition: service_healthy
@@ -49,7 +49,7 @@ services:
     image: redis:latest
     container_name: affine_redis
     healthcheck:
-      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+      test: ['CMD', 'redis-cli', '--raw', 'incr', 'ping']
       interval: 10s
       timeout: 5s
       retries: 5
@@ -59,11 +59,18 @@ services:
     image: pgvector/pgvector:pg16
     container_name: affine_postgres
     ports:
-      - "5432:5432"
+      - '5432:5432'
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready -U ${DB_USERNAME:-postgres}
+      interval: 10s
+      timeout: 5s
+      retries: 5
     volumes:
       - /c/Users/timhe/.affine/self-host/postgres/pgdata:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_DB: ${DB_DATABASE:-affine}
-      POSTGRES_INITDB_ARGS: "--data-checksums"
+      POSTGRES_INITDB_ARGS: '--data-checksums'

--- a/docker-compose.self-host.yml
+++ b/docker-compose.self-host.yml
@@ -33,7 +33,7 @@ services:
     restart: unless-stopped
 
   affine_migration:
-    image: ghcr.io/toeverything/affine:stable
+    image: ghcr.io/cognifex/affine:latest
     container_name: affine_migration_job
     command: ["sh", "-c", "node ./scripts/self-host-predeploy.js"]
     depends_on:


### PR DESCRIPTION
## Summary
- point the affine_migration service to ghcr.io/cognifex/affine:latest
- ensure migrations continue to run via the self-host predeploy script

## Testing
- docker compose up -d --force-recreate *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e918c9c1308324b0794066079c247c