### PR TITLE
Fix self-host compose defaults for Cognifex image

### DIFF
--- a/.docker/selfhost/compose.yml
+++ b/.docker/selfhost/compose.yml
@@ -19,22 +19,22 @@ services:
       - .env
     environment:
       - REDIS_SERVER_HOST=redis
-      - DATABASE_URL=postgresql://${DB_USERNAME}:${DB_PASSWORD}@postgres:5432/${DB_DATABASE:-affine}
+      - DATABASE_URL=postgresql://${DB_USERNAME:-postgres}:${DB_PASSWORD:-postgres}@postgres:5432/${DB_DATABASE:-affine}
       - AFFINE_INDEXER_ENABLED=false
     restart: unless-stopped
 
   affine_migration:
-    image: ghcr.io/toeverything/affine:stable
+    image: ghcr.io/cognifex/affine:latest
     container_name: affine_migration_job
     volumes:
       - /c/Users/timhe/.affine/self-host/storage:/root/.affine/storage
       - /c/Users/timhe/.affine/self-host/config:/root/.affine/config
-    command: ["sh", "-c", "node ./scripts/self-host-predeploy.js"]
+    command: ["node", "./scripts/self-host-predeploy.js"]
     env_file:
       - .env
     environment:
       - REDIS_SERVER_HOST=redis
-      - DATABASE_URL=postgresql://${DB_USERNAME}:${DB_PASSWORD}@postgres:5432/${DB_DATABASE:-affine}
+      - DATABASE_URL=postgresql://${DB_USERNAME:-postgres}:${DB_PASSWORD:-postgres}@postgres:5432/${DB_DATABASE:-affine}
       - AFFINE_INDEXER_ENABLED=false
     depends_on:
       postgres:
@@ -60,13 +60,13 @@ services:
     volumes:
       - /c/Users/timhe/.affine/self-host/postgres/pgdata:/var/lib/postgresql/data
     environment:
-      POSTGRES_USER: ${DB_USERNAME}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_USER: ${DB_USERNAME:-postgres}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-postgres}
       POSTGRES_DB: ${DB_DATABASE:-affine}
       POSTGRES_INITDB_ARGS: "--data-checksums"
       POSTGRES_HOST_AUTH_METHOD: trust
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "${DB_USERNAME}", "-d", "${DB_DATABASE:-affine}"]
+      test: ["CMD", "pg_isready", "-U", "${DB_USERNAME:-postgres}", "-d", "${DB_DATABASE:-affine}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.self-host.yml
+++ b/docker-compose.self-host.yml
@@ -4,7 +4,7 @@ services:
     image: ghcr.io/cognifex/affine:latest
     container_name: affine_server
     ports:
-      - "3010:3010"
+      - '3010:3010'
     healthcheck:
       test:
         - CMD-SHELL
@@ -28,28 +28,34 @@ services:
     environment:
       - AFFINE_SERVER_HOST=0.0.0.0
       - REDIS_SERVER_HOST=redis
-      - DATABASE_URL=postgresql://${DB_USERNAME}:${DB_PASSWORD}@postgres:5432/${DB_DATABASE:-affine}
+      - DATABASE_URL=postgresql://${DB_USERNAME:-postgres}:${DB_PASSWORD:-postgres}@postgres:5432/${DB_DATABASE:-affine}
       - AFFINE_INDEXER_ENABLED=false
     restart: unless-stopped
 
   affine_migration:
-    image: ghcr.io/toeverything/affine:stable
+    image: ghcr.io/cognifex/affine:latest
     container_name: affine_migration_job
-    command: ["sh", "-c", "node ./scripts/self-host-predeploy.js"]
+    command: ['node', './scripts/self-host-predeploy.js']
+    env_file:
+      - .env
+    volumes:
+      - /c/Users/timhe/.affine/self-host/storage:/root/.affine/storage
+      - /c/Users/timhe/.affine/self-host/config:/root/.affine/config
     depends_on:
       postgres:
         condition: service_healthy
       redis:
         condition: service_healthy
     environment:
-      - DATABASE_URL=postgresql://${DB_USERNAME}:${DB_PASSWORD}@postgres:5432/${DB_DATABASE:-affine}
+      - DATABASE_URL=postgresql://${DB_USERNAME:-postgres}:${DB_PASSWORD:-postgres}@postgres:5432/${DB_DATABASE:-affine}
       - REDIS_SERVER_HOST=redis
+      - AFFINE_INDEXER_ENABLED=false
 
   redis:
     image: redis:latest
     container_name: affine_redis
     healthcheck:
-      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+      test: ['CMD', 'redis-cli', '--raw', 'incr', 'ping']
       interval: 10s
       timeout: 5s
       retries: 5
@@ -59,11 +65,18 @@ services:
     image: pgvector/pgvector:pg16
     container_name: affine_postgres
     ports:
-      - "5432:5432"
+      - '5432:5432'
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready -U ${DB_USERNAME:-postgres}
+      interval: 10s
+      timeout: 5s
+      retries: 5
     volumes:
       - /c/Users/timhe/.affine/self-host/postgres/pgdata:/var/lib/postgresql/data
     environment:
-      POSTGRES_USER: ${DB_USERNAME}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_USER: ${DB_USERNAME:-postgres}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-postgres}
       POSTGRES_DB: ${DB_DATABASE:-affine}
-      POSTGRES_INITDB_ARGS: "--data-checksums"
+      POSTGRES_INITDB_ARGS: '--data-checksums'


### PR DESCRIPTION
## Summary
- add environment defaults so the self-host Postgres service and DATABASE_URL work without a custom .env
- run the Cognifex migration job with the same volumes/env file as the server container and invoke node directly
- keep AFFiNE indexer disabled in the migration container for consistent behavior

## Testing
- not run (docker is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e918c9c1308324b0794066079c247c